### PR TITLE
Added lots of rules for EditText and String

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,29 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <Objective-C-extensions>
+      <file>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      </file>
+      <class>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      </class>
+      <extensions>
+        <pair source="cpp" header="h" fileNamingConvention="NONE" />
+        <pair source="c" header="h" fileNamingConvention="NONE" />
+      </extensions>
+    </Objective-C-extensions>
+  </code_scheme>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,8 +5,6 @@
       <module fileurl="file://$PROJECT_DIR$/EasyValidation.iml" filepath="$PROJECT_DIR$/EasyValidation.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
-      <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
-      <module fileurl="file://$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" filepath="$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" />
       <module fileurl="file://$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" filepath="$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" />
       <module fileurl="file://$PROJECT_DIR$/ev.iml" filepath="$PROJECT_DIR$/ev.iml" />
     </modules>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,11 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/EasyValidation.iml" filepath="$PROJECT_DIR$/EasyValidation.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
+      <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
+      <module fileurl="file://$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" filepath="$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" />
       <module fileurl="file://$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" filepath="$PROJECT_DIR$/easyvalidation-core/easyvalidation-core.iml" />
       <module fileurl="file://$PROJECT_DIR$/ev.iml" filepath="$PROJECT_DIR$/ev.iml" />
     </modules>

--- a/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
+++ b/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
@@ -66,9 +66,11 @@ class MainActivity : AppCompatActivity() {
                     //if (edittext.greaterThanOrEqual(-10) == false)
                     //    edittext.error = "Number greater than or equal to 10"
 
-                    if (edittext.atleastOneSpecial() == false)
-                        edittext.error = "Should contain atleast 1 special characters"
+                    //if (edittext.textEqualTo("Hell0") == false)
+                    //    edittext.error = "Should be same as Hell0"
 
+                    if (edittext.creditCardNumberWithSpaces() == false)
+                        edittext.error = "Invalid credit card number!"
 
                     //if (edittext.validEmail() == false)
                     //    edittext.error = "Invalid email address!"

--- a/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
+++ b/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
@@ -69,8 +69,8 @@ class MainActivity : AppCompatActivity() {
                     //if (edittext.textEqualTo("Hell0") == false)
                     //    edittext.error = "Should be same as Hell0"
 
-                    if (edittext.creditCardNumberWithSpaces() == false)
-                        edittext.error = "Invalid credit card number!"
+                    if (edittext.validUrl() == false)
+                        edittext.error = "Invalid web URL!"
 
                     //if (edittext.validEmail() == false)
                     //    edittext.error = "Invalid email address!"

--- a/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
+++ b/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : AppCompatActivity() {
                     //        .check()
 
 
-                    if (edittext.greaterThanOrEqual(10))
+                    if (edittext.greaterThanOrEqual(-10) == false)
                         edittext.error = "Number greater than or equal to 10"
 
                     //if (edittext.validEmail() == false)

--- a/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
+++ b/app/src/main/java/com/wajahatkarim3/easyvalidation_demo/MainActivity.kt
@@ -63,8 +63,12 @@ class MainActivity : AppCompatActivity() {
                     //        .check()
 
 
-                    if (edittext.greaterThanOrEqual(-10) == false)
-                        edittext.error = "Number greater than or equal to 10"
+                    //if (edittext.greaterThanOrEqual(-10) == false)
+                    //    edittext.error = "Number greater than or equal to 10"
+
+                    if (edittext.atleastOneSpecial() == false)
+                        edittext.error = "Should contain atleast 1 special characters"
+
 
                     //if (edittext.validEmail() == false)
                     //    edittext.error = "Invalid email address!"

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
@@ -276,6 +276,12 @@ class Validator(val text: String)
         return this
     }
 
+    fun validUrl() : Validator
+    {
+        addRule(ValidUrlRule())
+        return this
+    }
+
     fun regex(pattern: String) : Validator
     {
         addRule(RegexRule(pattern))

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
@@ -144,6 +144,36 @@ class Validator(val text: String)
         return this
     }
 
+    fun allLowerCase() : Validator
+    {
+        addRule(AllLowerCaseRule())
+        return this
+    }
+
+    fun allUpperCase() : Validator
+    {
+        addRule(AllUpercCaseRule())
+        return this
+    }
+
+    fun atleastOneUpperCase() : Validator
+    {
+        addRule(AtLeastOneUpercCaseRule())
+        return this
+    }
+
+    fun atleastOneLowerCase() : Validator
+    {
+        addRule(AtLeastOneLowerCaseRule())
+        return this
+    }
+
+    fun atleastOneNumber() : Validator
+    {
+        addRule(AtLeastOneNumberCaseRule())
+        return this
+    }
+
     fun regex(pattern: String) : Validator
     {
         addRule(RegexRule(pattern))

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
@@ -174,6 +174,30 @@ class Validator(val text: String)
         return this
     }
 
+    fun startWithNumber() : Validator
+    {
+        addRule(StartsWithNumberRule())
+        return this
+    }
+
+    fun startWithNonNumber() : Validator
+    {
+        addRule(StartsWithNoNumberRule())
+        return this
+    }
+
+    fun noSpecialCharacters() : Validator
+    {
+        addRule(NoSpecialCharacterRule())
+        return this
+    }
+
+    fun atleastOneSpecialCharacters() : Validator
+    {
+        addRule(AtleastOneSpecialCharacterRule())
+        return this
+    }
+
     fun regex(pattern: String) : Validator
     {
         addRule(RegexRule(pattern))

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
@@ -132,6 +132,18 @@ class Validator(val text: String)
         return this
     }
 
+    fun lessThan(number: Number) : Validator
+    {
+        addRule(LessThanRule(number))
+        return this
+    }
+
+    fun lessThanOrEqual(number: Number) : Validator
+    {
+        addRule(LessThanOrEqualRule(number))
+        return this
+    }
+
     fun regex(pattern: String) : Validator
     {
         addRule(RegexRule(pattern))

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/Validator.kt
@@ -144,6 +144,12 @@ class Validator(val text: String)
         return this
     }
 
+    fun numberEqualTo(number: Number) : Validator
+    {
+        addRule(NumberEqualToRule(number))
+        return this
+    }
+
     fun allLowerCase() : Validator
     {
         addRule(AllLowerCaseRule())
@@ -174,6 +180,18 @@ class Validator(val text: String)
         return this
     }
 
+    fun noNumbers() : Validator
+    {
+        addRule(NoNumbersRule())
+        return this
+    }
+
+    fun onlyNumbers() : Validator
+    {
+        addRule(OnlyNumbersRule())
+        return this
+    }
+
     fun startWithNumber() : Validator
     {
         addRule(StartsWithNumberRule())
@@ -195,6 +213,66 @@ class Validator(val text: String)
     fun atleastOneSpecialCharacters() : Validator
     {
         addRule(AtleastOneSpecialCharacterRule())
+        return this
+    }
+
+    fun textEqualTo(target: String) : Validator
+    {
+        addRule(TextEqualToRule(target))
+        return this
+    }
+
+    fun textNotEqualTo(target: String) : Validator
+    {
+        addRule(TextNotEqualToRule(target))
+        return this
+    }
+
+    fun startsWith(target: String) : Validator
+    {
+        addRule(StartsWithRule(target))
+        return this
+    }
+
+    fun endsWith(target: String) : Validator
+    {
+        addRule(EndsWithRule(target))
+        return this
+    }
+
+    fun contains(target: String) : Validator
+    {
+        addRule(ContainsRule(target))
+        return this
+    }
+
+    fun notContains(target: String) : Validator
+    {
+        addRule(NotContainsRule(target))
+        return this
+    }
+
+    fun creditCardNumber() : Validator
+    {
+        addRule(MinLengthRule(16))
+        addRule(MaxLengthRule(16))
+        addRule(CreditCardRule())
+        return this
+    }
+
+    fun creditCardNumberWithSpaces() : Validator
+    {
+        addRule(MinLengthRule(19))
+        addRule(MaxLengthRule(19))
+        addRule(CreditCardWithSpacesRule())
+        return this
+    }
+
+    fun creditCardNumberWithDashes() : Validator
+    {
+        addRule(MinLengthRule(19))
+        addRule(MaxLengthRule(19))
+        addRule(CreditCardWithDashesRule())
         return this
     }
 

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AllLowerCaseRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AllLowerCaseRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns false if atleast one or more characters are upper case
+ *
+ * @author Wajahat Karim
+ */
+class AllLowerCaseRule : BaseRule
+{
+    override fun validate(text: String): Boolean = text == text.toLowerCase()
+
+    override fun getErrorMessage(): String = "All letters should be in lower case."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AllUpercCaseRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AllUpercCaseRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns false if atleast one or more characters are lower case
+ *
+ * @author Wajahat Karim
+ */
+class AllUpercCaseRule : BaseRule
+{
+    override fun validate(text: String): Boolean = text == text.toUpperCase()
+
+    override fun getErrorMessage(): String = "All letters should be in upper case."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneLowerCaseRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneLowerCaseRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if atleast one or more characters are lower case
+ *
+ * @author Wajahat Karim
+ */
+class AtLeastOneLowerCaseRule : BaseRule
+{
+    override fun validate(text: String): Boolean = Validator(text).regex("[A-Z0-9]+").check()
+
+    override fun getErrorMessage(): String = "At least one letter should be in lower case."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneNumberCaseRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneNumberCaseRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if atleast one or more characters are numbers
+ *
+ * @author Wajahat Karim
+ */
+class AtLeastOneNumberCaseRule : BaseRule
+{
+    override fun validate(text: String): Boolean = Validator(text).regex(".*\\d.*").check()
+
+    override fun getErrorMessage(): String = "At least one letter should be a number."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneUpercCaseRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtLeastOneUpercCaseRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if atleast one or more characters are upper case
+ *
+ * @author Wajahat Karim
+ */
+class AtLeastOneUpercCaseRule : BaseRule
+{
+    override fun validate(text: String): Boolean = Validator(text).regex("[a-z0-9]+").check()
+
+    override fun getErrorMessage(): String = "At least one letter should be in upper case."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtleastOneSpecialCharacterRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/AtleastOneSpecialCharacterRule.kt
@@ -1,0 +1,20 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if text contain at least one special characters
+ *
+ * @author Wajahat Karim
+ */
+class AtleastOneSpecialCharacterRule : BaseRule
+{
+    override fun validate(text: String): Boolean {
+        if (text.isEmpty())
+            return false
+
+        return !Validator(text).regex("[A-Za-z0-9]+").check()
+    }
+
+    override fun getErrorMessage(): String = "Should contain at least 1 special characters"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ContainsRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ContainsRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns true if the text contains the given text
+ *
+ * @author Wajahat Karim
+ */
+class ContainsRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
+        return text.contains(target)
+    }
+
+    override fun getErrorMessage(): String = "Should contain $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardRule.kt
@@ -1,0 +1,39 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import java.util.ArrayList
+
+
+
+/**
+ * Returns true if the text is valid credit card number
+ * This supports Visa, Master Card, American Express, Diners Club, Discover, and JCB
+ *
+ * @author Wajahat Karim
+ */
+class CreditCardRule : BaseRule {
+
+    override fun validate(text: String): Boolean {
+        val listOfPattern = ArrayList<String>()
+        val ptVisa = "^4[0-9]{6,}$"
+        listOfPattern.add(ptVisa)
+        val ptMasterCard = "^5[1-5][0-9]{5,}$"
+        listOfPattern.add(ptMasterCard)
+        val ptAmeExp = "^3[47][0-9]{5,}$"
+        listOfPattern.add(ptAmeExp)
+        val ptDinClb = "^3(?:0[0-5]|[68][0-9])[0-9]{4,}$"
+        listOfPattern.add(ptDinClb)
+        val ptDiscover = "^6(?:011|5[0-9]{2})[0-9]{3,}$"
+        listOfPattern.add(ptDiscover)
+        val ptJcb = "^(?:2131|1800|35[0-9]{3})[0-9]{3,}$"
+        listOfPattern.add(ptJcb)
+
+        for (pattern in listOfPattern)
+        {
+            if (text.matches(Regex(pattern)))
+                return true
+        }
+        return false
+    }
+
+    override fun getErrorMessage(): String = "Invalid Credit Card Number!"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardWithDashesRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardWithDashesRule.kt
@@ -1,0 +1,42 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import java.util.ArrayList
+
+
+
+/**
+ * Returns true if the text is valid credit card number with dashes between 4 characters
+ * This supports Visa, Master Card, American Express, Diners Club, Discover, and JCB
+ *
+ * @author Wajahat Karim
+ */
+class CreditCardWithDashesRule : BaseRule {
+
+    override fun validate(text: String): Boolean {
+        val listOfPattern = ArrayList<String>()
+        val ptVisa = "^4[0-9]{6,}$"
+        listOfPattern.add(ptVisa)
+        val ptMasterCard = "^5[1-5][0-9]{5,}$"
+        listOfPattern.add(ptMasterCard)
+        val ptAmeExp = "^3[47][0-9]{5,}$"
+        listOfPattern.add(ptAmeExp)
+        val ptDinClb = "^3(?:0[0-5]|[68][0-9])[0-9]{4,}$"
+        listOfPattern.add(ptDinClb)
+        val ptDiscover = "^6(?:011|5[0-9]{2})[0-9]{3,}$"
+        listOfPattern.add(ptDiscover)
+        val ptJcb = "^(?:2131|1800|35[0-9]{3})[0-9]{3,}$"
+        listOfPattern.add(ptJcb)
+
+        // remove all spaces
+        var newtext = text.replace("-", "")
+
+        for (pattern in listOfPattern)
+        {
+            if (newtext.matches(Regex(pattern)))
+                return true
+        }
+        return false
+    }
+
+    override fun getErrorMessage(): String = "Invalid Credit Card Number!"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardWithSpacesRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/CreditCardWithSpacesRule.kt
@@ -1,0 +1,42 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import java.util.ArrayList
+
+
+
+/**
+ * Returns true if the text is valid credit card number with spaces between 4 characters
+ * This supports Visa, Master Card, American Express, Diners Club, Discover, and JCB
+ *
+ * @author Wajahat Karim
+ */
+class CreditCardWithSpacesRule : BaseRule {
+
+    override fun validate(text: String): Boolean {
+        val listOfPattern = ArrayList<String>()
+        val ptVisa = "^4[0-9]{6,}$"
+        listOfPattern.add(ptVisa)
+        val ptMasterCard = "^5[1-5][0-9]{5,}$"
+        listOfPattern.add(ptMasterCard)
+        val ptAmeExp = "^3[47][0-9]{5,}$"
+        listOfPattern.add(ptAmeExp)
+        val ptDinClb = "^3(?:0[0-5]|[68][0-9])[0-9]{4,}$"
+        listOfPattern.add(ptDinClb)
+        val ptDiscover = "^6(?:011|5[0-9]{2})[0-9]{3,}$"
+        listOfPattern.add(ptDiscover)
+        val ptJcb = "^(?:2131|1800|35[0-9]{3})[0-9]{3,}$"
+        listOfPattern.add(ptJcb)
+
+        // remove all spaces
+        var newtext = text.replace(" ", "")
+
+        for (pattern in listOfPattern)
+        {
+            if (newtext.matches(Regex(pattern)))
+                return true
+        }
+        return false
+    }
+
+    override fun getErrorMessage(): String = "Invalid Credit Card Number!"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/EndsWithRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/EndsWithRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns true if the text ends with the given text
+ *
+ * @author Wajahat Karim
+ */
+class EndsWithRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
+        return text.endsWith(target)
+    }
+
+    override fun getErrorMessage(): String = "Should end with $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/EqualToRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/EqualToRule.kt
@@ -6,18 +6,11 @@ import java.math.BigInteger
 import java.text.NumberFormat
 
 /**
- * Returns false if the text is number less than the given target number
+ * Returns false if the text is a valid number and equal to the given target number
  *
  * @author Wajahat Karim
  */
-class GreaterThanRule : BaseRule {
-
-    var target: Number = 0
-
-    constructor(targetNum: Number)
-    {
-        target = targetNum
-    }
+class EqualToRule(val target: Number) : BaseRule {
 
     override fun validate(text: String): Boolean {
 
@@ -32,7 +25,7 @@ class GreaterThanRule : BaseRule {
             {
                 var number = NumberFormat.getNumberInstance().parse(txtNum)
                 number = number.toFloat() * -1
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() == target.toFloat())
             }
             return false
         }
@@ -41,12 +34,12 @@ class GreaterThanRule : BaseRule {
             if (text.validNumber())
             {
                 var number = NumberFormat.getNumberInstance().parse(text)
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() == target.toFloat())
             }
             return false
         }
     }
 
-    override fun getErrorMessage(): String = "Should be greater than $target"
+    override fun getErrorMessage(): String = "Should be equal to $target"
 
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/GreaterThanOrEqualRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/GreaterThanOrEqualRule.kt
@@ -13,6 +13,10 @@ import java.text.NumberFormat
 class GreaterThanOrEqualRule(val target: Number) : BaseRule {
 
     override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
         // Negative
         if (text.startsWith("-"))
         {
@@ -20,7 +24,8 @@ class GreaterThanOrEqualRule(val target: Number) : BaseRule {
             if (txtNum.validNumber())
             {
                 var number = NumberFormat.getNumberInstance().parse(txtNum)
-                return (number.toFloat() <= -1*target.toFloat())
+                number = number.toFloat() * -1
+                return (number.toFloat() >= target.toFloat())
             }
             return false
         }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/LessThanOrEqualRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/LessThanOrEqualRule.kt
@@ -6,18 +6,11 @@ import java.math.BigInteger
 import java.text.NumberFormat
 
 /**
- * Returns false if the text is number less than the given target number
+ * Returns false if the text is number greater than or equal to the given target number
  *
  * @author Wajahat Karim
  */
-class GreaterThanRule : BaseRule {
-
-    var target: Number = 0
-
-    constructor(targetNum: Number)
-    {
-        target = targetNum
-    }
+class LessThanOrEqualRule(val target: Number) : BaseRule {
 
     override fun validate(text: String): Boolean {
 
@@ -32,7 +25,7 @@ class GreaterThanRule : BaseRule {
             {
                 var number = NumberFormat.getNumberInstance().parse(txtNum)
                 number = number.toFloat() * -1
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() <= target.toFloat())
             }
             return false
         }
@@ -41,12 +34,12 @@ class GreaterThanRule : BaseRule {
             if (text.validNumber())
             {
                 var number = NumberFormat.getNumberInstance().parse(text)
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() <= target.toFloat())
             }
             return false
         }
     }
 
-    override fun getErrorMessage(): String = "Should be greater than $target"
+    override fun getErrorMessage(): String = "Should be less than or equal to $target"
 
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/LessThanRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/LessThanRule.kt
@@ -6,11 +6,11 @@ import java.math.BigInteger
 import java.text.NumberFormat
 
 /**
- * Returns false if the text is number less than the given target number
+ * Returns false if the text is number greater than the given target number
  *
  * @author Wajahat Karim
  */
-class GreaterThanRule : BaseRule {
+class LessThanRule : BaseRule {
 
     var target: Number = 0
 
@@ -32,7 +32,7 @@ class GreaterThanRule : BaseRule {
             {
                 var number = NumberFormat.getNumberInstance().parse(txtNum)
                 number = number.toFloat() * -1
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() < target.toFloat())
             }
             return false
         }
@@ -41,12 +41,12 @@ class GreaterThanRule : BaseRule {
             if (text.validNumber())
             {
                 var number = NumberFormat.getNumberInstance().parse(text)
-                return (number.toFloat() > target.toFloat())
+                return (number.toFloat() < target.toFloat())
             }
             return false
         }
     }
 
-    override fun getErrorMessage(): String = "Should be greater than $target"
+    override fun getErrorMessage(): String = "Should be less than $target"
 
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NoNumbersRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NoNumbersRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns false if the text any number or digit.
+ *
+ * @author Wajahat Karim
+ */
+class NoNumbersRule : BaseRule {
+
+    override fun validate(text: String): Boolean = !Validator(text).regex(".*\\d.*").check()
+
+    override fun getErrorMessage(): String = "Should not contain any numbers!"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NoSpecialCharacterRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NoSpecialCharacterRule.kt
@@ -1,0 +1,20 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if text contain no special characters
+ *
+ * @author Wajahat Karim
+ */
+class NoSpecialCharacterRule : BaseRule
+{
+    override fun validate(text: String): Boolean {
+        if (text.isEmpty())
+            return false
+
+        return Validator(text).regex("[A-Za-z0-9]+").check()
+    }
+
+    override fun getErrorMessage(): String = "Should not contain any special characters"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NotContainsRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NotContainsRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns false if the text contains the given text
+ *
+ * @author Wajahat Karim
+ */
+class NotContainsRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
+        return !text.contains(target)
+    }
+
+    override fun getErrorMessage(): String = "Should not contain $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NumberEqualToRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/NumberEqualToRule.kt
@@ -10,7 +10,7 @@ import java.text.NumberFormat
  *
  * @author Wajahat Karim
  */
-class EqualToRule(val target: Number) : BaseRule {
+class NumberEqualToRule(val target: Number) : BaseRule {
 
     override fun validate(text: String): Boolean {
 

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/OnlyNumbersRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/OnlyNumbersRule.kt
@@ -1,0 +1,15 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns false if text contains any alphabetic character
+ *
+ * @author Wajahat Karim
+ */
+class OnlyNumbersRule : BaseRule {
+
+    override fun validate(text: String): Boolean = Validator(text).regex("\\d+").check()
+
+    override fun getErrorMessage(): String = "Should not contain any alphabet characters!"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithNoNumberRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithNoNumberRule.kt
@@ -1,0 +1,20 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns false if text starts with any number
+ *
+ * @author Wajahat Karim
+ */
+class StartsWithNoNumberRule : BaseRule
+{
+    override fun validate(text: String): Boolean {
+        if (text.isEmpty())
+            return false
+
+        return !Validator(text).regex("^(\\d+.*|-\\d+.*)").check()
+    }
+
+    override fun getErrorMessage(): String = "Should not start with any number."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithNumberRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithNumberRule.kt
@@ -1,0 +1,20 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.Validator
+
+/**
+ * Returns true if text starts with any number
+ *
+ * @author Wajahat Karim
+ */
+class StartsWithNumberRule : BaseRule
+{
+    override fun validate(text: String): Boolean {
+        if (text.isEmpty())
+            return false
+
+        return Validator(text).regex("^(\\d+.*|-\\d+.*)").check()
+    }
+
+    override fun getErrorMessage(): String = "Should start with any number."
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/StartsWithRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns true if the text starts with the given text
+ *
+ * @author Wajahat Karim
+ */
+class StartsWithRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
+        return text.startsWith(target)
+    }
+
+    override fun getErrorMessage(): String = "Should start with $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/TextEqualToRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/TextEqualToRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns false if the text is not equal to the given text
+ *
+ * @author Wajahat Karim
+ */
+class TextEqualToRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return false
+
+        return text == target
+    }
+
+    override fun getErrorMessage(): String = "Should be equal to $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/TextNotEqualToRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/TextNotEqualToRule.kt
@@ -1,0 +1,25 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import com.wajahatkarim3.easyvalidation.core.view_ktx.validNumber
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+
+/**
+ * Returns true if the text is not equal to the given text
+ *
+ * @author Wajahat Karim
+ */
+class TextNotEqualToRule(val target: String) : BaseRule {
+
+    override fun validate(text: String): Boolean {
+
+        if (text.isEmpty())
+            return true
+
+        return text != target
+    }
+
+    override fun getErrorMessage(): String = "Should not be equal to $target"
+
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ValidNumberRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ValidNumberRule.kt
@@ -9,7 +9,21 @@ import com.wajahatkarim3.easyvalidation.core.Validator
  */
 class ValidNumberRule : BaseRule {
 
-    override fun validate(text: String): Boolean = Validator(text).regex("^[0-9]\\d*(\\.\\d+)?$").check()
+    override fun validate(text: String): Boolean
+    {
+        if (text.isEmpty())
+            return false
+
+        if (text.startsWith("-"))
+        {
+            var txtNum = text.substringAfter("-")
+            return Validator(txtNum).regex("^[0-9]\\d*(\\.\\d+)?$").check()
+        }
+        else
+        {
+            return Validator(text).regex("^[0-9]\\d*(\\.\\d+)?$").check()
+        }
+    }
 
     override fun getErrorMessage(): String = "Invalid Number!"
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ValidUrlRule.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/rules/ValidUrlRule.kt
@@ -1,0 +1,20 @@
+package com.wajahatkarim3.easyvalidation.core.rules
+
+import android.util.Patterns
+
+/**
+ * Returns true if the text is a valid URL
+ *
+ * @author Wajahat Karim
+ */
+class ValidUrlRule : BaseRule
+{
+    override fun validate(text: String): Boolean {
+        if (text.isEmpty())
+            return false
+
+        return Patterns.WEB_URL.matcher(text).matches()
+    }
+
+    override fun getErrorMessage(): String = "Invalid web URL"
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
@@ -4,6 +4,7 @@ import android.widget.EditText
 import com.wajahatkarim3.easyvalidation.core.Validator
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.util.regex.Pattern
 import kotlin.math.max
 
 fun EditText.validator() : Validator
@@ -56,6 +57,11 @@ fun EditText.lessThanOrEqual(number: Number) : Boolean
     return validator().lessThanOrEqual(number).check()
 }
 
+fun EditText.numberEqualTo(number: Number) : Boolean
+{
+    return validator().numberEqualTo(number).check()
+}
+
 fun EditText.allUperCase() : Boolean
 {
     return validator().allUpperCase().check()
@@ -91,12 +97,72 @@ fun EditText.startWithNonNumber() : Boolean
     return validator().startWithNonNumber().check()
 }
 
+fun EditText.noNumbers() : Boolean
+{
+    return validator().noNumbers().check()
+}
+
+fun EditText.onlyNumbers() : Boolean
+{
+    return validator().onlyNumbers().check()
+}
+
 fun EditText.noSpecialCharacters() : Boolean
 {
     return validator().noSpecialCharacters().check()
 }
 
-fun EditText.atleastOneSpecial() : Boolean
+fun EditText.atleastOneSpecialCharacters() : Boolean
 {
     return validator().atleastOneSpecialCharacters().check()
+}
+
+fun EditText.textEqualTo(target: String) : Boolean
+{
+    return validator().textEqualTo(target).check()
+}
+
+fun EditText.textNotEqualTo(target: String) : Boolean
+{
+    return validator().textNotEqualTo(target).check()
+}
+
+fun EditText.startsWith(target: String) : Boolean
+{
+    return validator().startsWith(target).check()
+}
+
+fun EditText.endssWith(target: String) : Boolean
+{
+    return validator().endsWith(target).check()
+}
+
+fun EditText.contains(target: String) : Boolean
+{
+    return validator().contains(target).check()
+}
+
+fun EditText.notContains(target: String) : Boolean
+{
+    return validator().notContains(target).check()
+}
+
+fun EditText.creditCardNumber() : Boolean
+{
+    return validator().creditCardNumber().check()
+}
+
+fun EditText.creditCardNumberWithSpaces() : Boolean
+{
+    return validator().creditCardNumberWithSpaces().check()
+}
+
+fun EditText.creditCardNumberWithDashes() : Boolean
+{
+    return validator().creditCardNumberWithDashes().check()
+}
+
+fun EditText.regex(pattern: String) : Boolean
+{
+    return validator().regex(pattern).check()
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
@@ -55,3 +55,28 @@ fun EditText.lessThanOrEqual(number: Number) : Boolean
 {
     return validator().lessThanOrEqual(number).check()
 }
+
+fun EditText.allUperCase() : Boolean
+{
+    return validator().allUpperCase().check()
+}
+
+fun EditText.allLowerCase() : Boolean
+{
+    return validator().allLowerCase().check()
+}
+
+fun EditText.atleastOneUpperCase() : Boolean
+{
+    return validator().atleastOneUpperCase().check()
+}
+
+fun EditText.atleastOneLowerCase() : Boolean
+{
+    return validator().atleastOneLowerCase().check()
+}
+
+fun EditText.atleastOneNumber() : Boolean
+{
+    return validator().atleastOneNumber().check()
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
@@ -38,10 +38,20 @@ fun EditText.validNumber() : Boolean
 
 fun EditText.greaterThan(number: Number) : Boolean
 {
-    return validator().validNumber().greaterThan(number).check()
+    return validator().greaterThan(number).check()
 }
 
 fun EditText.greaterThanOrEqual(number: Number) : Boolean
 {
-    return validator().validNumber().greaterThanOrEqual(number).check()
+    return validator().greaterThanOrEqual(number).check()
+}
+
+fun EditText.lessThan(number: Number) : Boolean
+{
+    return validator().lessThan(number).check()
+}
+
+fun EditText.lessThanOrEqual(number: Number) : Boolean
+{
+    return validator().lessThanOrEqual(number).check()
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
@@ -80,3 +80,23 @@ fun EditText.atleastOneNumber() : Boolean
 {
     return validator().atleastOneNumber().check()
 }
+
+fun EditText.startWithNumber() : Boolean
+{
+    return validator().startWithNumber().check()
+}
+
+fun EditText.startWithNonNumber() : Boolean
+{
+    return validator().startWithNonNumber().check()
+}
+
+fun EditText.noSpecialCharacters() : Boolean
+{
+    return validator().noSpecialCharacters().check()
+}
+
+fun EditText.atleastOneSpecial() : Boolean
+{
+    return validator().atleastOneSpecialCharacters().check()
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/EditTextKtx.kt
@@ -162,6 +162,11 @@ fun EditText.creditCardNumberWithDashes() : Boolean
     return validator().creditCardNumberWithDashes().check()
 }
 
+fun EditText.validUrl() : Boolean
+{
+    return validator().validUrl().check()
+}
+
 fun EditText.regex(pattern: String) : Boolean
 {
     return validator().regex(pattern).check()

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
@@ -55,6 +55,11 @@ fun String.lessThanOrEqual(number: Number) : Boolean
     return validator().lessThanOrEqual(number).check()
 }
 
+fun String.numberEqualTo(number: Number) : Boolean
+{
+    return validator().numberEqualTo(number).check()
+}
+
 fun String.allUperCase() : Boolean
 {
     return validator().allUpperCase().check()
@@ -90,12 +95,72 @@ fun String.startWithNonNumber() : Boolean
     return validator().startWithNonNumber().check()
 }
 
+fun String.noNumbers() : Boolean
+{
+    return validator().noNumbers().check()
+}
+
+fun String.onlyNumbers() : Boolean
+{
+    return validator().onlyNumbers().check()
+}
+
 fun String.noSpecialCharacters() : Boolean
 {
     return validator().noSpecialCharacters().check()
 }
 
-fun String.atleastOneSpecial() : Boolean
+fun String.atleastOneSpecialCharacters() : Boolean
 {
     return validator().atleastOneSpecialCharacters().check()
+}
+
+fun String.textEqualTo(target: String) : Boolean
+{
+    return validator().textEqualTo(target).check()
+}
+
+fun String.textNotEqualTo(target: String) : Boolean
+{
+    return validator().textNotEqualTo(target).check()
+}
+
+fun String.startsWith(target: String) : Boolean
+{
+    return validator().startsWith(target).check()
+}
+
+fun String.endsWith(target: String) : Boolean
+{
+    return validator().endsWith(target).check()
+}
+
+fun String.contains(target: String) : Boolean
+{
+    return validator().contains(target).check()
+}
+
+fun String.notContains(target: String) : Boolean
+{
+    return validator().notContains(target).check()
+}
+
+fun String.creditCardNumber() : Boolean
+{
+    return validator().creditCardNumber().check()
+}
+
+fun String.creditCardNumberWithSpaces() : Boolean
+{
+    return validator().creditCardNumberWithSpaces().check()
+}
+
+fun String.creditCardNumberWithDashes() : Boolean
+{
+    return validator().creditCardNumberWithDashes().check()
+}
+
+fun String.regex(pattern: String) : Boolean
+{
+    return validator().regex(pattern).check()
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
@@ -160,6 +160,11 @@ fun String.creditCardNumberWithDashes() : Boolean
     return validator().creditCardNumberWithDashes().check()
 }
 
+fun String.validUrl() : Boolean
+{
+    return validator().validUrl().check()
+}
+
 fun String.regex(pattern: String) : Boolean
 {
     return validator().regex(pattern).check()

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
@@ -54,3 +54,28 @@ fun String.lessThanOrEqual(number: Number) : Boolean
 {
     return validator().lessThanOrEqual(number).check()
 }
+
+fun String.allUperCase() : Boolean
+{
+    return validator().allUpperCase().check()
+}
+
+fun String.allLowerCase() : Boolean
+{
+    return validator().allLowerCase().check()
+}
+
+fun String.atleastOneUpperCase() : Boolean
+{
+    return validator().atleastOneUpperCase().check()
+}
+
+fun String.atleastOneLowerCase() : Boolean
+{
+    return validator().atleastOneLowerCase().check()
+}
+
+fun String.atleastOneNumber() : Boolean
+{
+    return validator().atleastOneNumber().check()
+}

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
@@ -37,10 +37,20 @@ fun String.validNumber() : Boolean
 
 fun String.greaterThan(number: Number) : Boolean
 {
-    return validator().validNumber().greaterThan(number).check()
+    return validator().greaterThan(number).check()
 }
 
 fun String.greaterThanOrEqual(number: Number) : Boolean
 {
-    return validator().validNumber().greaterThanOrEqual(number).check()
+    return validator().greaterThanOrEqual(number).check()
+}
+
+fun String.lessThan(number: Number) : Boolean
+{
+    return validator().lessThan(number).check()
+}
+
+fun String.lessThanOrEqual(number: Number) : Boolean
+{
+    return validator().lessThanOrEqual(number).check()
 }

--- a/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
+++ b/easyvalidation-core/src/main/java/com/wajahatkarim3/easyvalidation/core/view_ktx/StringKtx.kt
@@ -79,3 +79,23 @@ fun String.atleastOneNumber() : Boolean
 {
     return validator().atleastOneNumber().check()
 }
+
+fun String.startWithNumber() : Boolean
+{
+    return validator().startWithNumber().check()
+}
+
+fun String.startWithNonNumber() : Boolean
+{
+    return validator().startWithNonNumber().check()
+}
+
+fun String.noSpecialCharacters() : Boolean
+{
+    return validator().noSpecialCharacters().check()
+}
+
+fun String.atleastOneSpecial() : Boolean
+{
+    return validator().atleastOneSpecialCharacters().check()
+}


### PR DESCRIPTION
Added rules along with extensions for ```EditText``` and ```String```

Rules List is:
* All Lower Case
* All Upper Case
* At least one lower case
* At least one upper case
* At least one special character
* At least one number
* Contains
* Not contains
* Credit card (Visa, Master Card, American Express, Diners Club, Discover, and JCB) with spaces and dashes
* Valid Email 
* Ends with
* Greater than
* Greater than or equal to
* Less than
* less than or equal to
* number equal to
* text equal to
* text not equal to
* max length
* min length
* non empty
* no numbers
* no special characters
* only numbers
* Regex Rule to match any custom pattern
* Starts with
* Starts with no number
* Starts with number
* Valid Number
* Valid web url