### PR TITLE
Fix release tab link in Changelog section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 <br/>
 
 ## ✔️ Changelog
-Changes exist in the [releases](https://github.com/wajahatkarim3/MediumClap-Android/releases) tab.
+Changes exist in the [releases](https://github.com/wajahatkarim3/EasyValidation/releases) tab.
 
 ## 💻 Installation
 Add this in app's ```build.gradle``` file:


### PR DESCRIPTION
Fix the _releases tab_'s url in [`README.md`](https://github.com/wajahatkarim3/EasyValidation/blob/master/README.md#%EF%B8%8F-changelog) which points to [`MediumClap-Android`](https://github.com/wajahatkarim3/MediumClap-Android) project instead of [`EasyValidation`](https://github.com/wajahatkarim3/EasyValidation/).